### PR TITLE
attempts to improve speed

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -53,10 +53,7 @@ def test_main():
     i2v_steps = 50
     i2v_fps = 4
 
-    # with nullcontext():
-    #     key_frame_paths = [(str(p),) for p in Path('../nottempdir').iterdir()]
     with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir.mkdir(exist_ok=True)
         key_frame_paths = []
 
         for i, frame in enumerate(key_frames):

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,74 @@
+import tempfile
+from pathlib import Path
+from contextlib import contextmanager, nullcontext
+from time import perf_counter
+
+from tqdm import tqdm
+from PIL import Image
+from torch.profiler import profile, record_function, ProfilerActivity, schedule
+import numpy as np
+
+from gradio_app import process, process_video, interrogator_process
+
+@contextmanager
+def timeof(s: str | None = None):
+    duration = []
+    start_time = perf_counter()
+    yield lambda: duration[0]
+    end_time = perf_counter()
+    duration.append(end_time - start_time)
+    if s is not None:
+        print(f"{s}: {duration[0]}")
+
+
+DUMMY_PROGRESS = type('', (), dict(tqdm=tqdm))
+
+def test_main():
+    # Example input from dbs
+    input_fg_path = './imgs/1.jpg'
+    seed = 12345
+    i2v_seed = 123
+
+    # Load the input image
+    input_fg = np.array(Image.open(input_fg_path))
+
+    # Generate prompt
+    with timeof("Interrogator time") as t_prompt: prompt = interrogator_process(input_fg)
+    # prompt = """megumin, 1girl, solo, breasts, looking at viewer, blush, smile, short hair, open mouth, bangs, brown hair, red eyes, long sleeves, dress, bare shoulders, collarbone, upper body, :d, sidelocks, small breasts, choker, indoors, off shoulder, blurry, v-shaped eyebrows, blurry background, black choker, red dress, short hair with long locks, off-shoulder dress"""
+
+    # Generate key frames
+    input_undo_steps = [400]#, 600, 800, 900, 950, 999]
+    image_width = 512
+    image_height = 640
+    steps = 50
+    cfg = 3.0
+    n_prompt = 'lowres, bad anatomy, bad hands, cropped, worst quality'
+
+    # Create a fake progress object
+    with timeof("Processing time") as t_process: key_frames = process(input_fg, prompt, input_undo_steps, image_width, image_height, seed, steps, n_prompt, cfg, DUMMY_PROGRESS)
+
+    # Generate video
+    i2v_input_text = '1girl, masterpiece, best quality'
+    i2v_cfg_scale = 7.5
+    i2v_steps = 50
+    i2v_fps = 4
+
+    # with nullcontext():
+    #     key_frame_paths = [(str(p),) for p in Path('../nottempdir').iterdir()]
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir.mkdir(exist_ok=True)
+        key_frame_paths = []
+
+        for i, frame in enumerate(key_frames):
+            frame_path = Path(temp_dir) / f"frame_{i}.png"
+            Image.fromarray(frame).save(frame_path)
+            key_frame_paths.append((str(frame_path),))
+
+        print(key_frame_paths)
+        with timeof("Video generation time") as t_video:
+            output_filename, video = process_video(key_frame_paths, i2v_input_text, i2v_steps, i2v_cfg_scale, i2v_fps, i2v_seed, DUMMY_PROGRESS)
+
+    print(f"Generated video saved to: {output_filename}")
+
+# Run the test
+test_main()

--- a/diffusers_vdm/attention.py
+++ b/diffusers_vdm/attention.py
@@ -102,7 +102,7 @@ class CrossAttention(nn.Module):
         k_ip, v_ip, out_ip = None, None, None
 
         q = self.to_q(x)
-        context = default(context, x)
+        context = x if context is None else context
 
         if spatial_self_attn:
             k = self.to_k(context)

--- a/diffusers_vdm/attention.py
+++ b/diffusers_vdm/attention.py
@@ -136,6 +136,9 @@ class CrossAttention(nn.Module):
             v = self.to_v(context)
             k_ip = self.to_k_ip(context_image)
             v_ip = self.to_v_ip(context_image)
+            factor = k_ip.size(0) // k.size(0)
+            k = k.repeat_interleave(factor, dim=0)
+            v = v.repeat_interleave(factor, dim=0)
         else:
             raise NotImplementedError('Traditional prompt-only attention without IP-Adapter is illegal now.')
 

--- a/diffusers_vdm/dynamic_tsnr_sampler.py
+++ b/diffusers_vdm/dynamic_tsnr_sampler.py
@@ -170,7 +170,7 @@ class SamplerDynamicTSNR(torch.nn.Module):
     def model_apply(self, x, t, **extra_args):
         x = x.to(device=self.unet.device, dtype=self.unet.dtype)
         cfg_scale = extra_args['cfg_scale']
-        p = self.unet(x, t, **extra_args['positive'])
+        p = self.unet(x, t, **extra_args['positive']).clone()
         n = self.unet(x, t, **extra_args['negative'])
         o = n + cfg_scale * (p - n)
         o_better = rescale_noise_cfg(o, p, guidance_rescale=self.guidance_rescale)

--- a/diffusers_vdm/unet.py
+++ b/diffusers_vdm/unet.py
@@ -247,8 +247,8 @@ class ResBlock(TimestepBlock):
         else:
             h = self.in_layers(x)
         emb_out = self.emb_layers(emb).type(h.dtype)
-        while len(emb_out.shape) < len(h.shape):
-            emb_out = emb_out[..., None]
+        for _ in range(h.dim() - emb_out.dim()):
+            emb_out = emb_out.unsqueeze(-1)
         if self.use_scale_shift_norm:
             out_norm, out_rest = self.out_layers[0], self.out_layers[1:]
             scale, shift = torch.chunk(emb_out, 2, dim=1)

--- a/diffusers_vdm/unet.py
+++ b/diffusers_vdm/unet.py
@@ -594,10 +594,7 @@ class UNet3DModel(nn.Module, PyTorchModelHubMixin):
         t_emb = timestep_embedding(timesteps, self.model_channels, repeat_only=False).type(x.dtype)
         emb = self.time_embed(t_emb)
 
-        context_text = context_text.repeat_interleave(repeats=t, dim=0)
-        context_img = rearrange(context_img, 'b t l c -> (b t) l c')
-
-        context = (context_text, context_img)
+        context = (context_text, context_img.flatten(end_dim=1))
 
         if concat_cond is not None:
             x = torch.cat([x, concat_cond], dim=1)

--- a/diffusers_vdm/unet.py
+++ b/diffusers_vdm/unet.py
@@ -599,8 +599,6 @@ class UNet3DModel(nn.Module, PyTorchModelHubMixin):
 
         context = (context_text, context_img)
 
-        emb = emb.repeat_interleave(repeats=t, dim=0)
-
         if concat_cond is not None:
             x = torch.cat([x, concat_cond], dim=1)
 
@@ -615,8 +613,8 @@ class UNet3DModel(nn.Module, PyTorchModelHubMixin):
             fs_emb = timestep_embedding(fs, self.model_channels, repeat_only=False).type(x.dtype)
 
             fs_embed = self.fps_embedding(fs_emb)
-            fs_embed = fs_embed.repeat_interleave(repeats=t, dim=0)
             emb = emb + fs_embed
+        emb = emb.repeat_interleave(repeats=t, dim=0)
 
         h = x
         hs = []

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -111,13 +111,13 @@ def resize_without_crop(image, target_width, target_height):
 
 
 @torch.inference_mode()
-def interrogator_process(x):
+def interrogator_process(x: np.ndarray) -> str:
     return wd14tagger.default_interrogator(x)
 
 
 @torch.inference_mode()
-def process(input_fg, prompt, input_undo_steps, image_width, image_height, seed, steps, n_prompt, cfg,
-            progress=gr.Progress()):
+def process(input_fg: np.ndarray, prompt: str, input_undo_steps: list[int], image_width: int, image_height: int, 
+            seed: int, steps: int, n_prompt: str, cfg: float, progress: gr.Progress) -> list[np.ndarray]:
     rng = torch.Generator(device=memory_management.gpu).manual_seed(int(seed))
 
     memory_management.load_models_to_gpu(vae)
@@ -212,7 +212,7 @@ def process_video_inner(image_1, image_2, prompt, seed=123, steps=25, cfg_scale=
 
 
 @torch.inference_mode()
-def process_video(keyframes, prompt, steps, cfg, fps, seed, progress=gr.Progress()):
+def process_video(keyframes: list[tuple[str]], prompt: str, steps: int, cfg: float, fps: int, seed: int, progress=gr.Progress()):
     result_frames = []
     cropped_images = []
 
@@ -237,85 +237,86 @@ def process_video(keyframes, prompt, steps, cfg, fps, seed, progress=gr.Progress
     return output_filename, video
 
 
-block = gr.Blocks().queue()
-with block:
-    gr.Markdown('# Paints-Undo')
+if __name__  == "__main__":
+    block = gr.Blocks().queue()
+    with block:
+        gr.Markdown('# Paints-Undo')
 
-    with gr.Accordion(label='Step 1: Upload Image and Generate Prompt', open=True):
-        with gr.Row():
-            with gr.Column():
-                input_fg = gr.Image(sources=['upload'], type="numpy", label="Image", height=512)
-            with gr.Column():
-                prompt_gen_button = gr.Button(value="Generate Prompt", interactive=False)
-                prompt = gr.Textbox(label="Output Prompt", interactive=True)
+        with gr.Accordion(label='Step 1: Upload Image and Generate Prompt', open=True):
+            with gr.Row():
+                with gr.Column():
+                    input_fg = gr.Image(sources=['upload'], type="numpy", label="Image", height=512)
+                with gr.Column():
+                    prompt_gen_button = gr.Button(value="Generate Prompt", interactive=False)
+                    prompt = gr.Textbox(label="Output Prompt", interactive=True)
 
-    with gr.Accordion(label='Step 2: Generate Key Frames', open=True):
-        with gr.Row():
-            with gr.Column():
-                input_undo_steps = gr.Dropdown(label="Operation Steps", value=[400, 600, 800, 900, 950, 999],
-                                               choices=list(range(1000)), multiselect=True)
-                seed = gr.Slider(label='Stage 1 Seed', minimum=0, maximum=50000, step=1, value=12345)
-                image_width = gr.Slider(label="Image Width", minimum=256, maximum=1024, value=512, step=64)
-                image_height = gr.Slider(label="Image Height", minimum=256, maximum=1024, value=640, step=64)
-                steps = gr.Slider(label="Steps", minimum=1, maximum=100, value=50, step=1)
-                cfg = gr.Slider(label="CFG Scale", minimum=1.0, maximum=32.0, value=3.0, step=0.01)
-                n_prompt = gr.Textbox(label="Negative Prompt",
-                                      value='lowres, bad anatomy, bad hands, cropped, worst quality')
+        with gr.Accordion(label='Step 2: Generate Key Frames', open=True):
+            with gr.Row():
+                with gr.Column():
+                    input_undo_steps = gr.Dropdown(label="Operation Steps", value=[400, 600, 800, 900, 950, 999],
+                                                choices=list(range(1000)), multiselect=True)
+                    seed = gr.Slider(label='Stage 1 Seed', minimum=0, maximum=50000, step=1, value=12345)
+                    image_width = gr.Slider(label="Image Width", minimum=256, maximum=1024, value=512, step=64)
+                    image_height = gr.Slider(label="Image Height", minimum=256, maximum=1024, value=640, step=64)
+                    steps = gr.Slider(label="Steps", minimum=1, maximum=100, value=50, step=1)
+                    cfg = gr.Slider(label="CFG Scale", minimum=1.0, maximum=32.0, value=3.0, step=0.01)
+                    n_prompt = gr.Textbox(label="Negative Prompt",
+                                        value='lowres, bad anatomy, bad hands, cropped, worst quality')
 
-            with gr.Column():
-                key_gen_button = gr.Button(value="Generate Key Frames", interactive=False)
-                result_gallery = gr.Gallery(height=512, object_fit='contain', label='Outputs', columns=4)
+                with gr.Column():
+                    key_gen_button = gr.Button(value="Generate Key Frames", interactive=False)
+                    result_gallery = gr.Gallery(height=512, object_fit='contain', label='Outputs', columns=4)
 
-    with gr.Accordion(label='Step 3: Generate All Videos', open=True):
-        with gr.Row():
-            with gr.Column():
-                i2v_input_text = gr.Text(label='Prompts', value='1girl, masterpiece, best quality')
-                i2v_seed = gr.Slider(label='Stage 2 Seed', minimum=0, maximum=50000, step=1, value=123)
-                i2v_cfg_scale = gr.Slider(minimum=1.0, maximum=15.0, step=0.5, label='CFG Scale', value=7.5,
-                                          elem_id="i2v_cfg_scale")
-                i2v_steps = gr.Slider(minimum=1, maximum=60, step=1, elem_id="i2v_steps",
-                                      label="Sampling steps", value=50)
-                i2v_fps = gr.Slider(minimum=1, maximum=30, step=1, elem_id="i2v_motion", label="FPS", value=4)
-            with gr.Column():
-                i2v_end_btn = gr.Button("Generate Video", interactive=False)
-                i2v_output_video = gr.Video(label="Generated Video", elem_id="output_vid", autoplay=True,
-                                            show_share_button=True, height=512)
-        with gr.Row():
-            i2v_output_images = gr.Gallery(height=512, label="Output Frames", object_fit="contain", columns=8)
+        with gr.Accordion(label='Step 3: Generate All Videos', open=True):
+            with gr.Row():
+                with gr.Column():
+                    i2v_input_text = gr.Text(label='Prompts', value='1girl, masterpiece, best quality')
+                    i2v_seed = gr.Slider(label='Stage 2 Seed', minimum=0, maximum=50000, step=1, value=123)
+                    i2v_cfg_scale = gr.Slider(minimum=1.0, maximum=15.0, step=0.5, label='CFG Scale', value=7.5,
+                                            elem_id="i2v_cfg_scale")
+                    i2v_steps = gr.Slider(minimum=1, maximum=60, step=1, elem_id="i2v_steps",
+                                        label="Sampling steps", value=50)
+                    i2v_fps = gr.Slider(minimum=1, maximum=30, step=1, elem_id="i2v_motion", label="FPS", value=4)
+                with gr.Column():
+                    i2v_end_btn = gr.Button("Generate Video", interactive=False)
+                    i2v_output_video = gr.Video(label="Generated Video", elem_id="output_vid", autoplay=True,
+                                                show_share_button=True, height=512)
+            with gr.Row():
+                i2v_output_images = gr.Gallery(height=512, label="Output Frames", object_fit="contain", columns=8)
 
-    input_fg.change(lambda: ["", gr.update(interactive=True), gr.update(interactive=False), gr.update(interactive=False)],
-                    outputs=[prompt, prompt_gen_button, key_gen_button, i2v_end_btn])
+        input_fg.change(lambda: ["", gr.update(interactive=True), gr.update(interactive=False), gr.update(interactive=False)],
+                        outputs=[prompt, prompt_gen_button, key_gen_button, i2v_end_btn])
 
-    prompt_gen_button.click(
-        fn=interrogator_process,
-        inputs=[input_fg],
-        outputs=[prompt]
-    ).then(lambda: [gr.update(interactive=True), gr.update(interactive=True), gr.update(interactive=False)],
-           outputs=[prompt_gen_button, key_gen_button, i2v_end_btn])
+        prompt_gen_button.click(
+            fn=interrogator_process,
+            inputs=[input_fg],
+            outputs=[prompt]
+        ).then(lambda: [gr.update(interactive=True), gr.update(interactive=True), gr.update(interactive=False)],
+            outputs=[prompt_gen_button, key_gen_button, i2v_end_btn])
 
-    key_gen_button.click(
-        fn=process,
-        inputs=[input_fg, prompt, input_undo_steps, image_width, image_height, seed, steps, n_prompt, cfg],
-        outputs=[result_gallery]
-    ).then(lambda: [gr.update(interactive=True), gr.update(interactive=True), gr.update(interactive=True)],
-           outputs=[prompt_gen_button, key_gen_button, i2v_end_btn])
+        key_gen_button.click(
+            fn=process,
+            inputs=[input_fg, prompt, input_undo_steps, image_width, image_height, seed, steps, n_prompt, cfg],
+            outputs=[result_gallery]
+        ).then(lambda: [gr.update(interactive=True), gr.update(interactive=True), gr.update(interactive=True)],
+            outputs=[prompt_gen_button, key_gen_button, i2v_end_btn])
 
-    i2v_end_btn.click(
-        inputs=[result_gallery, i2v_input_text, i2v_steps, i2v_cfg_scale, i2v_fps, i2v_seed],
-        outputs=[i2v_output_video, i2v_output_images],
-        fn=process_video
-    )
+        i2v_end_btn.click(
+            inputs=[result_gallery, i2v_input_text, i2v_steps, i2v_cfg_scale, i2v_fps, i2v_seed],
+            outputs=[i2v_output_video, i2v_output_images],
+            fn=process_video
+        )
 
-    dbs = [
-        ['./imgs/1.jpg', 12345, 123],
-        ['./imgs/2.jpg', 37000, 12345],
-        ['./imgs/3.jpg', 3000, 3000],
-    ]
+        dbs = [
+            ['./imgs/1.jpg', 12345, 123],
+            ['./imgs/2.jpg', 37000, 12345],
+            ['./imgs/3.jpg', 3000, 3000],
+        ]
 
-    gr.Examples(
-        examples=dbs,
-        inputs=[input_fg, seed, i2v_seed],
-        examples_per_page=1024
-    )
+        gr.Examples(
+            examples=dbs,
+            inputs=[input_fg, seed, i2v_seed],
+            examples_per_page=1024
+        )
 
-block.queue().launch(server_name='0.0.0.0')
+    block.queue().launch(server_name='0.0.0.0')

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -117,7 +117,7 @@ def interrogator_process(x: np.ndarray) -> str:
 
 @torch.inference_mode()
 def process(input_fg: np.ndarray, prompt: str, input_undo_steps: list[int], image_width: int, image_height: int, 
-            seed: int, steps: int, n_prompt: str, cfg: float, progress: gr.Progress) -> list[np.ndarray]:
+            seed: int, steps: int, n_prompt: str, cfg: float, progress=gr.Progress()) -> list[np.ndarray]:
     rng = torch.Generator(device=memory_management.gpu).manual_seed(int(seed))
 
     memory_management.load_models_to_gpu(vae)

--- a/memory_management.py
+++ b/memory_management.py
@@ -10,6 +10,7 @@ torch.zeros((1, 1)).to(gpu, torch.float32)
 torch.cuda.empty_cache()
 
 models_in_gpu = []
+blacklist = set()
 
 
 @contextmanager
@@ -38,6 +39,8 @@ def load_models_to_gpu(models):
 
     if not high_vram:
         for m in models_to_unload:
+            if m.__class__.__name__ in blacklist:
+                continue
             with movable_bnb_model(m):
                 m.to(cpu)
             print('Unload to CPU:', m.__class__.__name__)


### PR DESCRIPTION
This branch attempts:
* to create a simple test (`benchmark.py`) to evaluate generation speed
* to reduce unnecessary computations in UNet3DModel
* to enable torch compile w/ cudagraphs in UNet3DModel

These changes do not (currently) produce significant speed improvements on eager execution. I find this odd and will attempt to profile the model later.

When compilation over `UNet3DModel.forward` is enabled with, e.g. `python3 gradio_app.py 640 512`, `process_video()` performance _is_ improved by 10% (i.e. 300s video generation -> 270s) on a 3090.